### PR TITLE
method was throwing an exception when recieving an error (4xx or 5xx)…

### DIFF
--- a/features/bootstrap/ApiFeatureContext.php
+++ b/features/bootstrap/ApiFeatureContext.php
@@ -163,7 +163,11 @@ class ApiFeatureContext implements Context
             }
 
             $this->lastResponse = $e->getResponse();
-            throw new \Exception('Bad response.');
+            // if we have no status code, something went wrong
+            if($this->lastResponse->getStatusCode() == null){
+                throw new \Exception('Bad response.');
+            }
+            
         }
     }
 


### PR DESCRIPTION
In guzzle 6.xx, the ClientException (thrown on 4xx responses) and ServerException (thrown on 5xx responses) both extend the BadResponseException, that way it was impossible to test an error in the api (404 or 401, both resulted in a `Bad response` message